### PR TITLE
Fix running on windows

### DIFF
--- a/bin/buildTokenData.js
+++ b/bin/buildTokenData.js
@@ -32,6 +32,10 @@ export function isTokenizableProperty(prop) {
   return config.designTokenProperties.includes(prop);
 }
 
+export function convertPathToURI(path) {
+  return encodeURI(path.replace(/\\/g, '/'));
+}
+
 /*
  * Parse a CSS file looking for Design Tokens based on list provided from config.
  *
@@ -135,19 +139,16 @@ async function getCssFilesList(
 
   const fileObjects = [];
   for (const file of files) {
-    const relativeFilePath = path.relative(repoPath, file);
-    const filePosix = path.posix.relative(repoPath, file);
-    const directory = path.dirname(relativeFilePath);
-    const directoryPosix = path.posix.dirname(relativeFilePath);
+    const relativePath = path.relative(repoPath, file);
+    const fileURI = convertPathToURI(relativePath);
+    const dirURI = convertPathToURI(path.dirname(relativePath));
     const fileName = path.basename(file);
     const propagationData = await getPropagationData(file);
     fileObjects.push({
       fileName,
       absolutePath: file,
-      relativePath: relativeFilePath,
-      filePosix,
-      directory,
-      directoryPosix,
+      fileURI,
+      dirURI,
       propagationData,
     });
   }
@@ -164,7 +165,7 @@ async function getCssFilesList(
 function groupFilesByDirectory(fileObjects) {
   const groupedByDir = fileObjects.reduce((groups, fileObj) => {
     // Use the directory property (an empty string indicates the repo root).
-    const dir = fileObj.directoryPosix || '.';
+    const dir = fileObj.dirURI || '.';
     if (!groups[dir]) {
       groups[dir] = {};
     }

--- a/bin/buildTokenData.js
+++ b/bin/buildTokenData.js
@@ -212,13 +212,6 @@ export function computeAverages(node) {
 
 if (process.argv[1] === import.meta.filename) {
   (async () => {
-    // console.log(await getPropagationData('../mozilla-unified/toolkit/content/widgets/moz-message-bar/moz-message-bar.css'));
-    /* console.log(
-      await getPropagationData(
-        '../mozilla-unified/browser/components/sidebar/sidebar.css',
-      ),
-    ); */
-
     const cssFilesList = await getCssFilesList(
       config.repoPath,
       config.includePatterns,

--- a/bin/buildTokenData.js
+++ b/bin/buildTokenData.js
@@ -136,14 +136,18 @@ async function getCssFilesList(
   const fileObjects = [];
   for (const file of files) {
     const relativeFilePath = path.relative(repoPath, file);
+    const filePosix = path.posix.relative(repoPath, file);
     const directory = path.dirname(relativeFilePath);
+    const directoryPosix = path.posix.dirname(relativeFilePath);
     const fileName = path.basename(file);
     const propagationData = await getPropagationData(file);
     fileObjects.push({
       fileName,
       absolutePath: file,
       relativePath: relativeFilePath,
+      filePosix,
       directory,
+      directoryPosix,
       propagationData,
     });
   }
@@ -160,7 +164,7 @@ async function getCssFilesList(
 function groupFilesByDirectory(fileObjects) {
   const groupedByDir = fileObjects.reduce((groups, fileObj) => {
     // Use the directory property (an empty string indicates the repo root).
-    const dir = fileObj.directory || '.';
+    const dir = fileObj.directoryPosix || '.';
     if (!groups[dir]) {
       groups[dir] = {};
     }

--- a/config.js
+++ b/config.js
@@ -1,25 +1,17 @@
+import { pathToFileURL } from 'node:url';
 import path from 'node:path';
 export const repoPath =
   process.env.MOZILLA_CENTRAL_REPO_PATH || '../mozilla-unified';
 
-let tokensPath = path.resolve(
+// pathToFileURL ensures a x-platform path for the dynamic import
+// otherwise this will fail on windows with
+// ERR_UNSUPORTED_ESM_URL_SCHEME
+const tokensPath = pathToFileURL(
   path.join(
     repoPath,
     '/toolkit/themes/shared/design-system/tokens-storybook.mjs',
   ),
 );
-
-/*
-  tgiles: We need to prepend file:// on Windows
-  otherwise the default ESM loader will error out with
-  ERR_UNSUPPORTED_ESM_URL_SCHEME. The relevant text from
-  the error is the following: "On Windows, absolute paths
-  must be valid file:// URLs."
-*/
-
-if (process.platform === 'win32') {
-  tokensPath = 'file://' + tokensPath;
-}
 
 const { storybookTables } = await import(tokensPath);
 

--- a/config.js
+++ b/config.js
@@ -2,9 +2,11 @@ import path from 'node:path';
 export const repoPath =
   process.env.MOZILLA_CENTRAL_REPO_PATH || '../mozilla-unified';
 
-let tokensPath = path.join(
-  repoPath,
-  '/toolkit/themes/shared/design-system/tokens-storybook.mjs',
+let tokensPath = path.resolve(
+  path.join(
+    repoPath,
+    '/toolkit/themes/shared/design-system/tokens-storybook.mjs',
+  ),
 );
 
 /*

--- a/config.js
+++ b/config.js
@@ -1,14 +1,25 @@
 import path from 'node:path';
-
 export const repoPath =
   process.env.MOZILLA_CENTRAL_REPO_PATH || '../mozilla-unified';
 
-const { storybookTables } = await import(
-  path.join(
-    repoPath,
-    '/toolkit/themes/shared/design-system/tokens-storybook.mjs',
-  )
+let tokensPath = path.join(
+  repoPath,
+  '/toolkit/themes/shared/design-system/tokens-storybook.mjs',
 );
+
+/*
+  tgiles: We need to prepend file:// on Windows
+  otherwise the default ESM loader will error out with
+  ERR_UNSUPPORTED_ESM_URL_SCHEME. The relevant text from
+  the error is the following: "On Windows, absolute paths
+  must be valid file:// URLs."
+*/
+
+if (process.platform === 'win32') {
+  tokensPath = 'file://' + tokensPath;
+}
+
+const { storybookTables } = await import(tokensPath);
 
 export default {
   repoPath,

--- a/src/content/directories.njk
+++ b/src/content/directories.njk
@@ -17,7 +17,7 @@ layout: base.njk
   {% for file in groupedFilesByDir[dir].files %}
     {% set filePropagation =  file.propagationData.percentage | round(2) %}
     <li>
-      <a href="/{{ file.filePosix | url }}">{{ file.fileName }}</a>
+      <a href="/{{ file.fileURI | url }}">{{ file.fileName }}</a>
       <span class="{{ filePropagation | rangeClass }}">{{ filePropagation }}%</span>
     </li>
   {% endfor %}

--- a/src/content/directories.njk
+++ b/src/content/directories.njk
@@ -17,7 +17,7 @@ layout: base.njk
   {% for file in groupedFilesByDir[dir].files %}
     {% set filePropagation =  file.propagationData.percentage | round(2) %}
     <li>
-      <a href="/{{ file.relativePath | url }}">{{ file.fileName }}</a>
+      <a href="/{{ file.filePosix | url }}">{{ file.fileName }}</a>
       <span class="{{ filePropagation | rangeClass }}">{{ filePropagation }}%</span>
     </li>
   {% endfor %}

--- a/src/content/files.njk
+++ b/src/content/files.njk
@@ -3,12 +3,12 @@ pagination:
   data: cssFilesList
   size: 1
   alias: file
-permalink: "/{{ file.relativePath }}/"
+permalink: "/{{ file.filePosix }}/"
 layout: base.njk
 
 ---
 
-<h1><a href="/{{ file.directory }}">{{ file.directory }}</a>/{{ file.fileName }}</h1>
+<h1><a href="/{{ file.directoryPosix }}">{{ file.directoryPosix }}</a>/{{ file.fileName }}</h1>
 {% set totalPropagation = file.propagationData.percentage %}
 <p><strong>Propagation:</strong> <span class="{{ totalPropagation | rangeClass }}">{{ totalPropagation }}%</span></p>
 

--- a/src/content/files.njk
+++ b/src/content/files.njk
@@ -3,12 +3,12 @@ pagination:
   data: cssFilesList
   size: 1
   alias: file
-permalink: "/{{ file.filePosix }}/"
+permalink: "/{{ file.fileURI }}/"
 layout: base.njk
 
 ---
 
-<h1><a href="/{{ file.directoryPosix }}">{{ file.directoryPosix }}</a>/{{ file.fileName }}</h1>
+<h1><a href="/{{ file.dirURI }}">{{ file.dirURI }}</a>/{{ file.fileName }}</h1>
 {% set totalPropagation = file.propagationData.percentage %}
 <p><strong>Propagation:</strong> <span class="{{ totalPropagation | rangeClass }}">{{ totalPropagation }}%</span></p>
 


### PR DESCRIPTION
Fixes #13 and #12

Converts windows slashes to expected URI format for permalinks and switch to use `pathToFileURL` to provide the file:// protocol URL for a cross platform import. 