### PR TITLE
Ignore unitless 1 value

### DIFF
--- a/config.js
+++ b/config.js
@@ -152,6 +152,7 @@ export default {
   // supports RegExp or string.
   excludedCSSValues: [
     0,
+    1,
     'auto',
     'currentColor',
     'inherit',

--- a/src/lib/tokenUtils.test.js
+++ b/src/lib/tokenUtils.test.js
@@ -56,6 +56,14 @@ describe('containsExcludedValue', () => {
     expect(containsExcludedValue('0')).toBe(true);
   });
 
+  test('should ignore unitless 1', () => {
+    expect(containsExcludedValue('1')).toBe(true);
+  });
+
+  test('should not ignore 1px', () => {
+    expect(containsExcludedValue('1px')).toBe(false);
+  });
+
   test('should ignore an a pattern match for calc()', () => {
     expect(containsExcludedValue('calc(100vh - 100px)')).toBe(true);
   });


### PR DESCRIPTION
Fixes #23

Before: 

<img width="271" alt="Firefox 2025-05-27 15 04 42" src="https://github.com/user-attachments/assets/37422d58-7f7b-414b-9cb4-4a7bfb01e0b6" />


After:

<img width="271" alt="Screenshot 2025-05-29 at 11 49 02" src="https://github.com/user-attachments/assets/e766f531-18f0-47e1-83c0-425997f34ea8" />

