### PR TITLE
Fix-up tooltip rendering

### DIFF
--- a/src/content/css/style.css
+++ b/src/content/css/style.css
@@ -78,7 +78,7 @@
   --status-good-background: rgba(0, 200, 0, 0.2);
   --status-good-border: 3px solid green;
   --status-good-external-background: rgba(0, 88, 255, 0.2);
-  --status-good-external-border: rgb(0, 88, 255);
+  --status-good-external-border: 3px solid rgb(0, 88, 255);
   --status-warn-background: rgba(255, 200, 0, 0.25);
   --status-warn-border: 3px solid orange;
   --status-bad-background: rgba(255, 0, 0, 0.15);
@@ -219,9 +219,10 @@ code {
     margin-inline-start: 0.2em;
   }
 }
-.awdty--external[data-status='good'] {
-  background-color: var(--status-good-external-background);
-  border-left: var(--status-good-external-border);
+[data-status='bad-excludedByStylelint'],
+[data-status='good-excludedByStylelint'] {
+  background-color: var(--status-warn-background);
+  border-left: var(--status-warn-border);
 
   :last-of-type::after {
     content: ' ℹ️';
@@ -229,8 +230,31 @@ code {
     margin-inline-start: 0.2em;
   }
 }
+[data-status='good-external'] {
+  background-color: var(--status-good-external-background);
+  border-left: var(--status-good-external-border);
 
-[data-status='excludedByStylelint'],
+  :last-of-type::after {
+    content: ' ☑️ ℹ️';
+    font-size: 0.9em;
+    margin-inline-start: 0.2em;
+  }
+}
+
+[data-status='bad-excludedByStylelint'] {
+  :last-of-type::after {
+    content: ' ⚠️';
+  }
+}
+[data-status='good-excludedByStylelint'] {
+  background-color: var(--status-good-external-background);
+  border-left: var(--status-good-external-border);
+
+  :last-of-type::after {
+    content: ' ☑️';
+  }
+}
+
 [data-status='warn'] {
   background-color: var(--status-warn-background);
   border-left: var(--status-warn-border);

--- a/src/content/js/TokenTooltip.js
+++ b/src/content/js/TokenTooltip.js
@@ -3,15 +3,21 @@
 import { LitElement, html, css } from 'lit';
 
 const messages = {
-  good: '🏆 Nice use of Design Tokens!',
-  'good-external': 'ℹ️ External Design Token Reference.',
-  warn: `☑️  This value doesn't need to use a Design Token.`,
+  good: '🏆 Uses Design Tokens!',
+  'good-external': 'ℹ️ Design Token Reference from an external file.',
+  warn: `☑️ This value is ignored`,
+  'bad-excludedByStylelint':
+    'ℹ️ Stylelint-disabled: but has no valid token for this property.',
+  'good-excludedByStylelint':
+    'ℹ️ Stylelint-disabled: but may actually be valid.',
+  'warn-excludedByStylelint':
+    'ℹ️ Stylelint-disabled: but looks to be an ignored value.',
   excludedByStylelint: html`This line is excluded by
     <code
       >/* stylelint-disable-next-line stylelint-plugin-mozilla/use-design-tokens
       */</code
     >.`,
-  bad: '❌ Not currently using a design token.',
+  bad: '❌ Not currently using a valid design token for this property.',
 };
 
 /**
@@ -129,13 +135,9 @@ export class TokenTooltip extends LitElement {
    * is unknown.
    *
    * @param {string} status The status key, e.g. "good", "bad"
-   * @param {string} resolutionType The resolution type, e.g. "external"
    * @returns {string} The corresponding status message
    */
-  getStatus(status, resolutionType) {
-    if (status === 'good' && resolutionType === 'external') {
-      return messages['good-external'];
-    }
+  getStatusMessage(status) {
     return messages[status] || messages.bad;
   }
 
@@ -147,27 +149,25 @@ export class TokenTooltip extends LitElement {
     return html`
       <div aria-live="polite">
         <div class="status" data-status=${this.status}>
-          ${this.getStatus(this.status, this.resolutionType)}
+          ${this.getStatusMessage(this.status)}
         </div>
         ${this.isExcludedByStylelint
           ? html`
               <div class="note">
                 <p>${messages.excludedByStylelint}</p>
-                ${this.resolutionType === 'external' && this.status === 'good'
+                ${this.status === 'good-external'
                   ? html`<p>
                       This is likely to have been excluded since the stylelint
                       rules only process local vars.
                     </p>`
                   : ''}
-                ${this.status === 'good'
-                  ? html`<p>This line is still counted as a token.</p>`
+                ${this.status.startsWith('good')
+                  ? html`<p>This line is still counted as a valid token.</p>`
                   : ''}
               </div>
             `
           : ''}
-        ${this.resolutionType === 'external' &&
-        this.status === 'good' &&
-        !this.isExcludedByStylelint
+        ${this.status === 'good-external' && !this.isExcludedByStylelint
           ? html`<div class="note">
               <p>
                 Note: Since var resolution points to an external file, the
@@ -185,7 +185,9 @@ export class TokenTooltip extends LitElement {
           : ''}
         ${this.tokens.length
           ? html`
-              <div class="label">🎨 Design Tokens Used:</div>
+              <div class="label">
+                🎨 Valid Design Tokens Used for this prop:
+              </div>
               <ul>
                 ${this.tokens.map(
                   (token) => html`<li><code>${token}</code></li>`,

--- a/src/content/js/TokenTooltip.test.js
+++ b/src/content/js/TokenTooltip.test.js
@@ -39,10 +39,130 @@ describe('<token-tooltip>', () => {
 
     await tooltip.updateComplete;
 
+    expect(tooltip.shadowRoot.textContent).toContain('Uses Design Tokens');
     expect(tooltip.shadowRoot.textContent).toContain('Design Tokens Used');
     expect(tooltip.shadowRoot.textContent).toContain('--a');
     expect(tooltip.shadowRoot.textContent).toContain('Trace');
     expect(tooltip.shadowRoot.textContent).toContain('1rem');
+  });
+
+  test('renders ignored content as warning', async () => {
+    tooltip = setupTooltip({
+      status: 'warn',
+      trace: ['1rem'],
+      tokens: [],
+    });
+
+    await tooltip.updateComplete;
+
+    expect(tooltip.shadowRoot.textContent).toContain('This value is ignored');
+    expect(tooltip.shadowRoot.textContent).not.toContain('Trace');
+    expect(tooltip.shadowRoot.textContent).not.toContain('1rem');
+  });
+
+  test('renders bad content correctly', async () => {
+    tooltip = setupTooltip({
+      status: 'bad',
+      trace: ['1rem'],
+      tokens: [],
+    });
+
+    await tooltip.updateComplete;
+
+    expect(tooltip.shadowRoot.textContent).toContain(
+      'Not currently using a valid design token for this property',
+    );
+  });
+
+  test('renders stylelint-disabled content when bad', async () => {
+    tooltip = setupTooltip({
+      isExcludedByStylelint: true,
+      status: 'bad-excludedByStylelint',
+      trace: ['1rem'],
+      tokens: [],
+    });
+
+    await tooltip.updateComplete;
+
+    expect(tooltip.shadowRoot.textContent).toContain(
+      'Stylelint-disabled: but has no valid token for this property',
+    );
+  });
+
+  test('renders stylelint-disabled content when a warning', async () => {
+    tooltip = setupTooltip({
+      isExcludedByStylelint: true,
+      status: 'warn-excludedByStylelint',
+      trace: ['1rem'],
+      tokens: [],
+    });
+
+    await tooltip.updateComplete;
+
+    expect(tooltip.shadowRoot.textContent).toContain(
+      'Stylelint-disabled: but looks to be an ignored value.',
+    );
+  });
+
+  test('renders stylelint-disabled content when good', async () => {
+    tooltip = setupTooltip({
+      isExcludedByStylelint: true,
+      status: 'good-excludedByStylelint',
+      trace: ['1rem'],
+      tokens: [],
+    });
+
+    await tooltip.updateComplete;
+
+    expect(tooltip.shadowRoot.textContent).toContain(
+      'Stylelint-disabled: but may actually be valid',
+    );
+    expect(tooltip.shadowRoot.textContent).toContain(
+      'This line is still counted as a valid token.',
+    );
+  });
+
+  test('renders stylelint-disabled content when an external design token ref', async () => {
+    tooltip = setupTooltip({
+      isExcludedByStylelint: true,
+      resolutionType: 'external',
+      status: 'good-external',
+      trace: ['1rem'],
+      tokens: [],
+    });
+
+    await tooltip.updateComplete;
+
+    expect(tooltip.shadowRoot.textContent).toContain(
+      'Design Token Reference from an external file',
+    );
+    expect(tooltip.shadowRoot.textContent).toContain(
+      'This line is still counted as a valid token.',
+    );
+    expect(tooltip.shadowRoot.textContent).toContain(
+      'This is likely to have been excluded',
+    );
+  });
+
+  test('renders an external design token ref', async () => {
+    tooltip = setupTooltip({
+      resolutionType: 'external',
+      status: 'good-external',
+      trace: ['1rem'],
+      tokens: [],
+    });
+
+    await tooltip.updateComplete;
+
+    expect(tooltip.shadowRoot.textContent).toContain(
+      'Design Token Reference from an external file',
+    );
+    expect(tooltip.shadowRoot.textContent).toContain(
+      'This line is still counted as a valid token.',
+    );
+    expect(tooltip.shadowRoot.textContent).toContain(
+      'consider adding a comment to disable the specific line',
+    );
   });
 
   test('does not render trace if only one step', async () => {

--- a/src/lib/loadAndAnnotateFile.js
+++ b/src/lib/loadAndAnnotateFile.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs/promises';
 import { codeToHtml } from 'shiki';
-import { isDesignToken } from './tokenUtils.js';
+import { isDesignToken, extractValidTokensForProp } from './tokenUtils.js';
 
 /**
  * Removes consecutive duplicate values from a resolution trace.
@@ -26,13 +26,32 @@ function dedupeTrace(trace = []) {
  * @param {boolean} prop.isValidPropertyValue whether this property/value combination is valid.
  * @returns {'good' | 'warn' | 'bad'} - The resolution status.
  */
-function getStatus(prop) {
-  let status = prop.containsValidDesignToken
-    ? 'good'
-    : prop.isValidPropertyValue
-      ? 'warn'
-      : 'bad';
-  return status;
+export function getStatus(prop) {
+  if (prop.resolutionType === 'external' && prop.containsValidDesignToken) {
+    return 'good-external';
+  }
+
+  if (prop.isExcludedByStylelint && prop.containsValidDesignToken) {
+    return 'good-excludedByStylelint';
+  }
+
+  if (prop.isExcludedByStylelint && !prop.isValidPropertyValue) {
+    return 'bad-excludedByStylelint';
+  }
+
+  if (prop.isExcludedByStylelint && prop.isValidPropertyValue) {
+    return 'warn-excludedByStylelint';
+  }
+
+  if (prop.containsValidDesignToken) {
+    return 'good';
+  }
+
+  if (prop.isValidPropertyValue) {
+    return 'warn';
+  }
+
+  return 'bad';
 }
 
 /**
@@ -40,7 +59,7 @@ function getStatus(prop) {
  *
  * Extracts trace, tokens used, resolution sources, and unresolved variables.
  *
- * @param {object} prop - A resolved property with metadata from analysis.
+ * @param {object} decl - A resolved declaration with metadata from analysis.
  * @returns {{
  *   status: string,
  *   trace: string[],
@@ -50,32 +69,31 @@ function getStatus(prop) {
  *   resolutionType: string,
  * }}
  */
-function extractTooltipData(prop) {
-  const status = getStatus(prop);
-  const trace = dedupeTrace(prop.resolutionTrace || []);
+function extractTooltipData(decl) {
+  const status = getStatus(decl);
+  const trace = dedupeTrace(decl.resolutionTrace || []);
 
-  const unresolved = (prop.unresolvedVariables || []).filter(
+  // We only care about non-canonical tokens that aren't resolved.
+  const unresolved = (decl.unresolvedVariables || []).filter(
     (v) => !isDesignToken(v),
   );
 
-  const tokensUsed = new Set();
+  const validTokensUsed = new Set();
   for (const step of trace) {
-    const matches = step.match(/--[\w-]+/g) || [];
-    for (const token of matches) {
-      if (isDesignToken(token)) {
-        tokensUsed.add(token);
-      }
+    const extractedTokens = extractValidTokensForProp(decl.prop, step);
+    for (const token of extractedTokens) {
+      validTokensUsed.add(token);
     }
   }
 
   return {
     status,
     trace,
-    tokens: [...tokensUsed],
-    source: prop.resolutionSources || [],
+    tokens: [...validTokensUsed],
+    source: decl.resolutionSources || [],
     unresolved,
-    resolutionType: prop.resolutionType,
-    isExcludedByStylelint: prop.isExcludedByStylelint,
+    resolutionType: decl.resolutionType,
+    isExcludedByStylelint: decl.isExcludedByStylelint,
   };
 }
 
@@ -93,10 +111,10 @@ export default async function loadAndAnnotateFile(filePath, foundPropValues) {
   const content = await fs.readFile(filePath, 'utf8');
   const decorations = [];
 
-  for (const prop of foundPropValues) {
-    const { start, end, resolutionType } = prop;
+  for (const decl of foundPropValues) {
+    const { start, end, resolutionType } = decl;
 
-    const tooltipData = extractTooltipData(prop);
+    const tooltipData = extractTooltipData(decl);
 
     decorations.push({
       start: {

--- a/src/lib/loadAndAnnotateFile.test.js
+++ b/src/lib/loadAndAnnotateFile.test.js
@@ -1,5 +1,6 @@
 import fs from 'fs/promises';
 import loadAndAnnotateFile from './loadAndAnnotateFile.js';
+import { getStatus } from './loadAndAnnotateFile.js';
 
 /**
  *
@@ -15,6 +16,87 @@ function getOffsetRange(lineText, snippet) {
   const endColumn = startColumn + snippet.length;
   return { startColumn, endColumn };
 }
+
+describe('getStatus', () => {
+  test(`it returns 'good-external' when external ref and has a design token`, () => {
+    expect(
+      getStatus({
+        resolutionType: 'external',
+        containsValidDesignToken: true,
+        isValidPropertyValue: true,
+      }),
+    ).toBe('good-external');
+  });
+
+  test(`it returns 'warn' when external ref and does not have a design token but is a valid prop`, () => {
+    expect(
+      getStatus({
+        resolutionType: 'external',
+        containsValidDesignToken: false,
+        isValidPropertyValue: true,
+      }),
+    ).toBe('warn');
+  });
+
+  test(`it returns 'bar' when external ref and does not have a design token or valid prop`, () => {
+    expect(
+      getStatus({
+        resolutionType: 'external',
+        containsValidDesignToken: false,
+        isValidPropertyValue: false,
+      }),
+    ).toBe('bad');
+  });
+
+  test(`it returns 'warn' when external ref and does not have a design token but is a valid prop`, () => {
+    expect(
+      getStatus({
+        resolutionType: 'external',
+        containsValidDesignToken: false,
+        isValidPropertyValue: true,
+      }),
+    ).toBe('warn');
+  });
+
+  test(`it returns 'good-excludedByStylelint' when a valid token and valid prop value`, () => {
+    expect(
+      getStatus({
+        isExcludedByStylelint: true,
+        containsValidDesignToken: true,
+        isValidPropertyValue: true,
+      }),
+    ).toBe('good-excludedByStylelint');
+  });
+
+  test(`it returns 'warn-excludedByStylelint' when not a valid token but is a valid prop value`, () => {
+    expect(
+      getStatus({
+        isExcludedByStylelint: true,
+        containsValidDesignToken: false,
+        isValidPropertyValue: true,
+      }),
+    ).toBe('warn-excludedByStylelint');
+  });
+
+  test(`it returns 'bad-excludedByStylelint' when not a valid token or prop value`, () => {
+    expect(
+      getStatus({
+        isExcludedByStylelint: true,
+        containsValidDesignToken: false,
+        isValidPropertyValue: false,
+      }),
+    ).toBe('bad-excludedByStylelint');
+  });
+
+  test(`it returns 'good' when is both a valid token and prop value`, () => {
+    expect(
+      getStatus({
+        containsValidDesignToken: true,
+        isValidPropertyValue: true,
+      }),
+    ).toBe('good');
+  });
+});
 
 describe('loadAndAnnotateFile', () => {
   beforeEach(() => {
@@ -56,7 +138,7 @@ describe('loadAndAnnotateFile', () => {
         resolutionSources: ['tokens/colors.css'],
         unresolvedVariables: [],
         containsValidDesignToken: true,
-        containsExcludedDeclaration: false,
+        isValidPropertyValue: true,
       },
     ];
 

--- a/src/lib/tokenUtils.js
+++ b/src/lib/tokenUtils.js
@@ -28,22 +28,28 @@ export function isDesignToken(tokenName) {
 }
 
 /**
- * Returns true if the value contains a valid canonical design token for the property.
+ * Returns the canonical set of valid design tokens for a given CSS property.
  *
- * @param {string} prop - The CSS property to inspect.
- * @param {string} value - The CSS value to inspect.
- * @returns {boolean} - true if a design token key is found in the value.
+ * Builds a Set of token names derived from the property's configured token
+ * types and alias token types. This intentionally excludes any additional
+ * tokens introduced by stylelint rules, ensuring the result reflects only
+ * the canonical token definitions.
+ *
+ * If the property is not defined in the configuration, an empty Set is returned.
+ *
+ * @param {string} prop The CSS property name.
+ * @returns {Set<string>} A Set of valid canonical token names for the property.
  */
-function __containsValidDesignToken(prop, value) {
+function __getValidTokensForProp(prop) {
   const propConfig = propertyConfig[prop];
   if (!propConfig) {
-    return false;
+    return new Set();
   }
 
   // This is the canonical set of tokens for the prop, which is needed
   // as the stylelint rules add some overrides to the list of validTokenNames
   // but we want to stick to canonical tokens for this check.
-  const validCanonicalTokenNames = new Set(
+  return new Set(
     propConfig.validTypes.flatMap((propType) => [
       ...(propType.tokenTypes || []).flatMap((tokenType) =>
         tokensTable[tokenType].map((token) => token.name),
@@ -53,6 +59,59 @@ function __containsValidDesignToken(prop, value) {
       ),
     ]),
   );
+}
+
+export const getValidTokensForProp = memoize(__getValidTokensForProp);
+
+/**
+ * Extracts valid design tokens referenced in a CSS value for a given property.
+ *
+ * Parses the provided value, looks for CSS `var()` functions, and returns a Set
+ * of token names that are both:
+ * - referenced in the value, and
+ * - valid for the given property.
+ *
+ * If the value does not contain any valid design tokens for the property,
+ * an empty Set is returned.
+ *
+ * @param {string} prop The CSS property name being evaluated.
+ * @param {string} value The CSS value to parse.
+ * @returns {Set<string>} A Set of valid design token names found in the value.
+ */
+export function extractValidTokensForProp(prop, value) {
+  let collection = new Set();
+  if (containsValidDesignToken(prop, value)) {
+    const validCanonicalTokensForProp = getValidTokensForProp(prop);
+    const parsedValue = valueParser(value);
+
+    parsedValue.walk((node) => {
+      if (node.type === 'function' && node.value === 'var') {
+        const [varNameNode] = node.nodes;
+        const varName = varNameNode.value;
+
+        if (validCanonicalTokensForProp.has(varName)) {
+          collection.add(varName);
+        }
+      }
+      return undefined;
+    });
+  }
+
+  return collection;
+}
+
+/**
+ * Returns true if the value contains a valid canonical design token for the property.
+ *
+ * @param {string} prop - The CSS property to inspect.
+ * @param {string} value - The CSS value to inspect.
+ * @returns {boolean} - true if a design token key is found in the value.
+ */
+function __containsValidDesignToken(prop, value) {
+  const validCanonicalTokensForProp = getValidTokensForProp(prop);
+  if (!validCanonicalTokensForProp) {
+    return false;
+  }
 
   const parsedValue = valueParser(value);
   let found = false;
@@ -66,7 +125,7 @@ function __containsValidDesignToken(prop, value) {
       const [varNameNode] = node.nodes;
       const varName = varNameNode.value;
 
-      if (validCanonicalTokenNames.has(varName)) {
+      if (validCanonicalTokensForProp.has(varName)) {
         found = true;
         return false;
       }

--- a/src/lib/tokenUtils.test.js
+++ b/src/lib/tokenUtils.test.js
@@ -1,10 +1,12 @@
 import {
   isVariableDefinition,
   containsValidDesignToken,
+  getValidTokensForProp,
   isValidPropertyValue,
   isTokenizableProperty,
   getCSSVariables,
   isWithinValidParentSelector,
+  extractValidTokensForProp,
   extractDesignTokenIdsFromDecl,
 } from './tokenUtils.js';
 
@@ -27,6 +29,32 @@ describe('isVariableDefinition', () => {
 
   test('should return false for []', () => {
     expect(isVariableDefinition([])).toBe(false);
+  });
+});
+
+describe('getValidTokensForProp', () => {
+  test(`should return valid tokens for 'border'`, () => {
+    const validTokens = getValidTokensForProp('border');
+    expect(validTokens).toContain('--border-color');
+  });
+});
+
+describe('extractValidTokensForProp', () => {
+  test(`should return valid tokens for 'border'`, () => {
+    const extractedTokens = extractValidTokensForProp(
+      'border',
+      '1px solid var(--focus-outline)',
+    );
+    expect(extractedTokens).not.toContain('1px');
+    expect(extractedTokens).toContain('--focus-outline');
+  });
+
+  test(`should return valid tokens for 'border'`, () => {
+    const extractedTokens = extractValidTokensForProp(
+      'padding-inline-end',
+      'var(--space-xsmall)',
+    );
+    expect(extractedTokens).toContain('--space-xsmall');
   });
 });
 


### PR DESCRIPTION
Fixes #155

- The list of tokens was listing any arbitrary token used rather than those valid for the prop. That's fixed here. 
- Also the style and content shown wasn't quite right and this cleans that up, makes it consistent and adds tests. 