### PR TITLE
Update vendored code 14-04-26

### DIFF
--- a/src/lib/propagationUtils.js
+++ b/src/lib/propagationUtils.js
@@ -268,9 +268,7 @@ async function resolveDeclarationReferences(
     decl.containsValidDesignToken = analysis.containsValidDesignToken;
     decl.isValidPropertyValue = analysis.isValidPropertyValue;
 
-    const isIgnoredValue =
-      (decl.isExcludedByStylelint || analysis.isValidPropertyValue) &&
-      !analysis.containsValidDesignToken;
+    const isIgnored = isIgnoredValue(decl);
 
     decl.resolutionSources = getResolutionSources(
       trace,
@@ -295,6 +293,7 @@ async function resolveDeclarationReferences(
       decl,
       CANONICAL_TOKEN_KEY_SET,
     );
+
     if (tokenIds.length > 0) {
       decl.tokens = tokenIds;
     }
@@ -303,8 +302,8 @@ async function resolveDeclarationReferences(
       path: filePath,
       property: decl.prop,
       value: decl.value,
+      isIgnored,
       containsToken: Boolean(decl.containsValidDesignToken),
-      isIgnored: isIgnoredValue,
       ...(tokenIds.length > 0 ? { tokens: tokenIds } : {}),
     });
   }
@@ -329,6 +328,30 @@ async function resolveDeclarationReferences(
 }
 
 /**
+ * Determines whether a declaration value should be ignored when calculating
+ * design token propagation metrics.
+ *
+ * A value is ignored if:
+ * - It is excluded by stylelint and is not a valid property value
+ * - It is a valid property value but does not contain a valid design token
+ *
+ * Please note: Valid property values that contain tokens excluded by stylelint are still
+ * included in propagation metrics.
+ *
+ * @param {object} decl Declaration metadata
+ * @param {boolean} decl.isExcludedByStylelint Whether the value is excluded by stylelint rules
+ * @param {boolean} decl.isValidPropertyValue Whether the value is a valid CSS property value
+ * @param {boolean} decl.containsValidDesignToken Whether the value contains a valid design token
+ * @returns {boolean} Whether the value should be ignored
+ */
+export function isIgnoredValue(decl) {
+  return (
+    (decl.isExcludedByStylelint && !decl.isValidPropertyValue) ||
+    (decl.isValidPropertyValue && !decl.containsValidDesignToken)
+  );
+}
+
+/**
  * Computes summary statistics from the resolved declarations:
  * - Number of declarations using design tokens
  * - Number of ignored values (valid property values that dont't contain design tokens)
@@ -342,15 +365,7 @@ function computeDesignTokenSummary(declarations) {
       // To be counted as a token needs to be a valid prop *and* contain a token.
       (d) => d.containsValidDesignToken && d.isValidPropertyValue,
     ).length,
-    ignoredValueCount: declarations.filter(
-      (d) =>
-        // Ignore bad values excluded by stylelint.
-        // Note: Values that are valid props and contain tokens excluded by stylelint are
-        // still counted in propagation metrics.
-        (d.isExcludedByStylelint && !d.isValidPropertyValue) ||
-        // Ignore values that are valid props but don't contain tokens.
-        (d.isValidPropertyValue && !d.containsValidDesignToken),
-    ).length,
+    ignoredValueCount: declarations.filter(isIgnoredValue).length,
   };
 }
 

--- a/src/lib/propagationUtils.js
+++ b/src/lib/propagationUtils.js
@@ -51,6 +51,7 @@ export function normalizePathForOutput(absolutePath) {
  * - Calculating a token usage percentage
  *
  * @param {string} filePath - Absolute path to the CSS file.
+ * @param {Function} _collectExternalVars - optional function for dependency injection.
  * @returns {Promise<{
  *   designTokenCount: number,
  *   foundProps: number,
@@ -59,9 +60,13 @@ export function normalizePathForOutput(absolutePath) {
  *   foundVariables: object
  * }>} - Summary object including token count, percentage, and annotated data.
  */
-export async function getPropagationData(filePath) {
+export async function getPropagationData(
+  filePath,
+  _collectExternalVars = collectExternalVars,
+) {
   try {
-    const foundVariables = await collectExternalVars(filePath);
+    const foundVariables = await _collectExternalVars(filePath);
+
     const root = await parseCSS(filePath);
 
     const foundPropValues = collectDeclarations(root, foundVariables, filePath);
@@ -104,7 +109,7 @@ export async function getPropagationData(filePath) {
  * @param {string} filePath - The file path to match against config.externalVarMapping.
  * @returns {Promise<object>} - Map of variable names to external variable metadata.
  */
-async function collectExternalVars(filePath) {
+export async function collectExternalVars(filePath) {
   let foundVariables = {};
 
   for (const pattern in config.externalVarMapping) {
@@ -334,12 +339,17 @@ async function resolveDeclarationReferences(
 function computeDesignTokenSummary(declarations) {
   return {
     designTokenCount: declarations.filter(
+      // To be counted as a token needs to be a valid prop *and* contain a token.
       (d) => d.containsValidDesignToken && d.isValidPropertyValue,
     ).length,
     ignoredValueCount: declarations.filter(
       (d) =>
-        (d.isExcludedByStylelint || d.isValidPropertyValue) &&
-        !d.containsValidDesignToken,
+        // Ignore bad values excluded by stylelint.
+        // Note: Values that are valid props and contain tokens excluded by stylelint are
+        // still counted in propagation metrics.
+        (d.isExcludedByStylelint && !d.isValidPropertyValue) ||
+        // Ignore values that are valid props but don't contain tokens.
+        (d.isValidPropertyValue && !d.containsValidDesignToken),
     ).length,
   };
 }

--- a/src/lib/propagationUtils.test.js
+++ b/src/lib/propagationUtils.test.js
@@ -30,6 +30,89 @@ describe('getPropagationData', () => {
     vi.resetAllMocks();
   });
 
+  test('still detects tokens referenced via external files', async () => {
+    const css = `
+      .btn {
+        border: 1px solid var(--fxview-border);
+      }
+    `;
+    const filePath = '/project/test.css';
+    fs.readFile.mockResolvedValue(css);
+
+    const fakeExtVars = {
+      '--fxview-border': {
+        value: 'var(--border-color-transparent)',
+        isExternal: true,
+        start: { column: 3, line: 24, offset: 1308 },
+        end: { column: 51, line: 24, offset: 1357 },
+        src: 'firefoxview.css',
+      },
+    };
+
+    const fakeCollectExternalVars = vi.fn();
+    fakeCollectExternalVars.mockResolvedValueOnce(fakeExtVars);
+
+    const result = await getPropagationData(filePath, fakeCollectExternalVars);
+    expect(result.percentage).toBe(100);
+    expect(result.designTokenCount).toBe(1);
+
+    const props = result.foundPropValues;
+
+    expect(props).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          prop: 'border',
+          containsValidDesignToken: true,
+          isValidPropertyValue: true,
+          resolutionType: 'external',
+          isExcludedByStylelint: false,
+        }),
+      ]),
+    );
+  });
+
+  test('still counts valid tokens that are stylelint excluded and external refs', async () => {
+    const css = `
+      .btn {
+        /* stylelint-disable-next-line stylelint-plugin-mozilla/use-design-tokens -- some other comment */
+        border: 1px solid var(--fxview-border);
+      }
+    `;
+    const filePath = '/project/test.css';
+    fs.readFile.mockResolvedValue(css);
+
+    const fakeExtVars = {
+      '--fxview-border': {
+        value: 'var(--border-color-transparent)',
+        isExternal: true,
+        start: { column: 3, line: 24, offset: 1308 },
+        end: { column: 51, line: 24, offset: 1357 },
+        src: 'firefoxview.css',
+      },
+    };
+
+    const fakeCollectExternalVars = vi.fn();
+    fakeCollectExternalVars.mockResolvedValueOnce(fakeExtVars);
+
+    const result = await getPropagationData(filePath, fakeCollectExternalVars);
+    expect(result.percentage).toBe(100);
+    expect(result.designTokenCount).toBe(1);
+
+    const props = result.foundPropValues;
+
+    expect(props).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          prop: 'border',
+          containsValidDesignToken: true,
+          isValidPropertyValue: true,
+          resolutionType: 'external',
+          isExcludedByStylelint: true,
+        }),
+      ]),
+    );
+  });
+
   test('detects tokens used in vars defined and used in the same rule', async () => {
     const css = `
       :host {
@@ -144,12 +227,12 @@ describe('getPropagationData', () => {
     );
   });
 
-  test('excludes non-aliased base token usage', async () => {
+  test('ignores invalid token usage with preceding (use-design-tokens) stylelint-disable-next-line comment', async () => {
     const css = `
       .btn {
-        background-color: #fff;
-        /* This is not allowed because it's using a base token directly */
-        color: var(--color-accent-primary);
+        /* stylelint-disable-next-line stylelint-plugin-mozilla/use-design-tokens -- some other comment */
+        background-color: var(--color-gray-80);
+        color: var(--button-text-color-primary);
         border-color: #000;
       }
     `;
@@ -163,9 +246,9 @@ describe('getPropagationData', () => {
 
     expect(result).toHaveProperty('foundPropValues');
     expect(result).toHaveProperty('foundVariables');
-    // 0 design token found out of 3 that can be tokenized = 0
-    expect(result.percentage).toBe(0);
-    expect(result.designTokenCount).toBe(0);
+    // 1 design token found out of 2 that can be tokenized = 50%
+    expect(result.percentage).toBe(50);
+    expect(result.designTokenCount).toBe(1);
     expect(fs.writeFile).toHaveBeenCalled();
 
     expect(props).toEqual(
@@ -173,8 +256,58 @@ describe('getPropagationData', () => {
         expect.objectContaining({
           prop: 'background-color',
           isValidPropertyValue: false,
+          isExcludedByStylelint: true,
+          containsValidDesignToken: true,
+        }),
+        expect.objectContaining({
+          prop: 'color',
+          isValidPropertyValue: true,
+          isExcludedByStylelint: false,
+          containsValidDesignToken: true,
+        }),
+        expect.objectContaining({
+          prop: 'border-color',
+          isValidPropertyValue: false,
           isExcludedByStylelint: false,
           containsValidDesignToken: false,
+        }),
+      ]),
+    );
+  });
+
+  test('excludes non-aliased base token usage', async () => {
+    const css = `
+      .btn {
+        /* Some unaliased based tokens are allowed directly - see ...versatileColorTokens
+         * landed in https://bugzilla.mozilla.org/show_bug.cgi?id=2022975 */
+        background-color: var(--color-accent-primary);
+        /* Not allowed unless aliased */
+        color: var(--color-gray-80);
+        border-color: #000;
+      }
+    `;
+
+    fs.readFile.mockResolvedValueOnce(css);
+    const result = await getPropagationData(
+      '/project/src/components/button.css',
+    );
+
+    const props = result.foundPropValues;
+
+    expect(result).toHaveProperty('foundPropValues');
+    expect(result).toHaveProperty('foundVariables');
+    // 1 design token found out of 3 that can be tokenized = 33.33
+    expect(result.percentage).toBe(33.33);
+    expect(result.designTokenCount).toBe(1);
+    expect(fs.writeFile).toHaveBeenCalled();
+
+    expect(props).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          prop: 'background-color',
+          isValidPropertyValue: true,
+          isExcludedByStylelint: false,
+          containsValidDesignToken: true,
         }),
         expect.objectContaining({
           prop: 'color',
@@ -195,10 +328,10 @@ describe('getPropagationData', () => {
   test('excludes non-token usage with preceding (use-design-tokens) stylelint-disable-next-line comment', async () => {
     const css = `
       .btn {
-        --my-alias: var(--color-accent-primary);
+        --my-alias: var(--color-gray-80);
         /* stylelint-disable-next-line stylelint-plugin-mozilla/use-design-tokens -- some other comment */
         background-color: #fff;
-        /* This is allowed because it's aliasing --color-accent-primary */
+        /* This is allowed because it's aliasing --color-gray-80 */
         color: var(--my-alias);
         /* stylelint-disable-next-line */
         border-color: #000;

--- a/src/lib/resolutionUtils.test.js
+++ b/src/lib/resolutionUtils.test.js
@@ -79,14 +79,25 @@ describe('analyzeTrace', () => {
     expect(result.isValidPropertyValue).toBe(true);
   });
 
-  test('unaliased based color token will not pass isValidPropertyValue check', () => {
+  // See ...versatileColorTokens landed in https://bugzilla.mozilla.org/show_bug.cgi?id=2022975
+  test('some unaliased base color tokens will not pass isValidPropertyValue check', () => {
+    const trace = ['var(--color-gray-80)'];
+    const result = analyzeTrace(trace, {
+      prop: 'color',
+      value: 'var(--color-gray-80)',
+    });
+    expect(result.containsValidDesignToken).toBe(true);
+    expect(result.isValidPropertyValue).toBe(false);
+  });
+
+  test('some specific unaliased base color tokens will pass isValidPropertyValue check', () => {
     const trace = ['var(--color-accent-primary)'];
     const result = analyzeTrace(trace, {
       prop: 'color',
       value: 'var(--color-accent-primary)',
     });
     expect(result.containsValidDesignToken).toBe(true);
-    expect(result.isValidPropertyValue).toBe(false);
+    expect(result.isValidPropertyValue).toBe(true);
   });
 
   test('detects font-weight: normal specific exclusion', () => {

--- a/src/lib/tokenUtils.test.js
+++ b/src/lib/tokenUtils.test.js
@@ -94,8 +94,7 @@ describe('isValidPropertyValue', () => {
     );
   });
 
-  test(`should be true for some specific unaliased base tokens`, () => {
-    // This must be aliased to be allowed.
+  test(`should be false for unaliased base tokens`, () => {
     expect(isValidPropertyValue('color', 'var(--color-gray-80)')).toBe(false);
   });
 

--- a/src/lib/tokenUtils.test.js
+++ b/src/lib/tokenUtils.test.js
@@ -87,17 +87,22 @@ describe('containsValidDesignToken', () => {
 });
 
 describe('isValidPropertyValue', () => {
-  test(`should be true for a base token`, () => {
-    // This should be aliased to be allowed.
+  // See ...versatileColorTokens landed in https://bugzilla.mozilla.org/show_bug.cgi?id=2022975
+  test(`should be true for some specific unaliased base tokens`, () => {
     expect(isValidPropertyValue('color', 'var(--color-accent-primary)')).toBe(
-      false,
+      true,
     );
+  });
+
+  test(`should be true for some specific unaliased base tokens`, () => {
+    // This must be aliased to be allowed.
+    expect(isValidPropertyValue('color', 'var(--color-gray-80)')).toBe(false);
   });
 
   test('should allow an aliased base token', () => {
     expect(
       isValidPropertyValue('color', 'var(--local-var)', {
-        '--local-var': 'var(--color-accent-primary)',
+        '--local-var': 'var(--color-gray-80)',
       }),
     ).toBe(true);
   });

--- a/src/vendor/firefox/toolkit/themes/shared/design-system/dist/semantic-categories.mjs
+++ b/src/vendor/firefox/toolkit/themes/shared/design-system/dist/semantic-categories.mjs
@@ -295,6 +295,10 @@ export const tokensTable = {
       name: "--badge-background-color-filled",
     },
     {
+      value: "var(--background-color-information)",
+      name: "--message-bar-background-color",
+    },
+    {
       value: "var(--button-background-color)",
       name: "--toggle-background-color",
     },
@@ -576,6 +580,13 @@ export const tokensTable = {
       },
       name: "--badge-border-color-filled",
     },
+    {
+      value: {
+        default: "oklch(from var(--message-bar-icon-color) l c h / 20%)",
+        prefersContrast: "var(--border-color)",
+      },
+      name: "--message-bar-border-color",
+    },
     { value: "var(--border-color-interactive)", name: "--toggle-border-color" },
     {
       value: {
@@ -601,6 +612,10 @@ export const tokensTable = {
     { value: "var(--border-radius-medium)", name: "--button-border-radius" },
     { value: "var(--border-radius-large)", name: "--card-border-radius" },
     { value: "var(--border-radius-small)", name: "--badge-border-radius" },
+    {
+      value: "var(--border-radius-medium)",
+      name: "--message-bar-border-radius",
+    },
     { value: "var(--border-radius-circle)", name: "--toggle-border-radius" },
     {
       value: "var(--toolbarbutton-border-radius)",
@@ -610,6 +625,7 @@ export const tokensTable = {
   "border-width": [
     { value: "1px", name: "--border-width" },
     { value: "1px", name: "--badge-border-width" },
+    { value: "var(--border-width)", name: "--message-bar-border-width" },
     { value: "var(--border-width)", name: "--toggle-border-width" },
   ],
   "box-shadow": [
@@ -1050,6 +1066,10 @@ export const tokensTable = {
       value: { brand: { default: "664px" } },
       name: "--page-main-content-width",
     },
+    {
+      value: "var(--size-item-large)",
+      name: "--message-bar-container-min-height",
+    },
     { value: "var(--size-item-small)", name: "--toggle-height" },
     { value: "var(--size-item-large)", name: "--toggle-width" },
     {
@@ -1382,6 +1402,7 @@ export const tokensTable = {
       },
       name: "--badge-text-color-filled",
     },
+    { value: "var(--text-color)", name: "--message-bar-text-color" },
   ],
   border: [
     {
@@ -1437,6 +1458,10 @@ export const tokensTable = {
       },
       name: "--icon-color-critical",
     },
+    {
+      value: "var(--icon-color-information)",
+      name: "--message-bar-icon-color",
+    },
     { value: "var(--color-blue-50)", name: "--tab-loading-fill" },
   ],
   opacity: [
@@ -1452,6 +1477,7 @@ export const tokensTable = {
     { value: "var(--dimension-20)", name: "--icon-size-medium" },
     { value: "var(--dimension-24)", name: "--icon-size-large" },
     { value: "var(--dimension-32)", name: "--icon-size-xlarge" },
+    { value: "var(--icon-size)", name: "--message-bar-icon-size" },
   ],
   uncategorized: [
     { value: "var(--toolbar-bgcolor)", name: "--tab-selected-bgcolor" },
@@ -2322,6 +2348,17 @@ export const variableLookupTable = {
   },
   "badge-border-radius": "var(--border-radius-small)",
   "badge-border-width": "1px",
+  "message-bar-background-color": "var(--background-color-information)",
+  "message-bar-border-color": {
+    default: "oklch(from var(--message-bar-icon-color) l c h / 20%)",
+    prefersContrast: "var(--border-color)",
+  },
+  "message-bar-border-radius": "var(--border-radius-medium)",
+  "message-bar-border-width": "var(--border-width)",
+  "message-bar-container-min-height": "var(--size-item-large)",
+  "message-bar-icon-color": "var(--icon-color-information)",
+  "message-bar-icon-size": "var(--icon-size)",
+  "message-bar-text-color": "var(--text-color)",
   "toggle-background-color": "var(--button-background-color)",
   "toggle-background-color-hover": "var(--button-background-color-hover)",
   "toggle-background-color-active": "var(--button-background-color-active)",

--- a/src/vendor/firefox/toolkit/themes/shared/design-system/dist/tokens-table.mjs
+++ b/src/vendor/firefox/toolkit/themes/shared/design-system/dist/tokens-table.mjs
@@ -279,6 +279,10 @@ export const tokensTable = {
       name: "--badge-background-color-filled",
     },
     {
+      value: "var(--background-color-information)",
+      name: "--message-bar-background-color",
+    },
+    {
       value: "var(--button-background-color)",
       name: "--toggle-background-color",
     },
@@ -553,6 +557,13 @@ export const tokensTable = {
       },
       name: "--badge-border-color-filled",
     },
+    {
+      value: {
+        default: "oklch(from var(--message-bar-icon-color) l c h / 20%)",
+        prefersContrast: "var(--border-color)",
+      },
+      name: "--message-bar-border-color",
+    },
     { value: "var(--border-color-interactive)", name: "--toggle-border-color" },
     {
       value: {
@@ -578,6 +589,10 @@ export const tokensTable = {
     { value: "var(--border-radius-medium)", name: "--button-border-radius" },
     { value: "var(--border-radius-large)", name: "--card-border-radius" },
     { value: "var(--border-radius-small)", name: "--badge-border-radius" },
+    {
+      value: "var(--border-radius-medium)",
+      name: "--message-bar-border-radius",
+    },
     { value: "var(--border-radius-circle)", name: "--toggle-border-radius" },
     {
       value: "var(--toolbarbutton-border-radius)",
@@ -587,6 +602,7 @@ export const tokensTable = {
   "border-width": [
     { value: "1px", name: "--border-width" },
     { value: "1px", name: "--badge-border-width" },
+    { value: "var(--border-width)", name: "--message-bar-border-width" },
     { value: "var(--border-width)", name: "--toggle-border-width" },
   ],
   "box-shadow": [
@@ -1023,6 +1039,10 @@ export const tokensTable = {
       value: { brand: { default: "664px" } },
       name: "--page-main-content-width",
     },
+    {
+      value: "var(--size-item-large)",
+      name: "--message-bar-container-min-height",
+    },
     { value: "var(--size-item-small)", name: "--toggle-height" },
     { value: "var(--size-item-large)", name: "--toggle-width" },
     {
@@ -1343,6 +1363,7 @@ export const tokensTable = {
       },
       name: "--badge-text-color-filled",
     },
+    { value: "var(--text-color)", name: "--message-bar-text-color" },
   ],
   border: [
     {
@@ -1398,6 +1419,10 @@ export const tokensTable = {
       },
       name: "--icon-color-critical",
     },
+    {
+      value: "var(--icon-color-information)",
+      name: "--message-bar-icon-color",
+    },
     { value: "var(--color-blue-50)", name: "--tab-loading-fill" },
   ],
   opacity: [
@@ -1413,6 +1438,7 @@ export const tokensTable = {
     { value: "var(--dimension-20)", name: "--icon-size-medium" },
     { value: "var(--dimension-24)", name: "--icon-size-large" },
     { value: "var(--dimension-32)", name: "--icon-size-xlarge" },
+    { value: "var(--icon-size)", name: "--message-bar-icon-size" },
   ],
   "table-background": [
     {
@@ -2324,6 +2350,17 @@ export const variableLookupTable = {
   },
   "badge-border-radius": "var(--border-radius-small)",
   "badge-border-width": "1px",
+  "message-bar-background-color": "var(--background-color-information)",
+  "message-bar-border-color": {
+    default: "oklch(from var(--message-bar-icon-color) l c h / 20%)",
+    prefersContrast: "var(--border-color)",
+  },
+  "message-bar-border-radius": "var(--border-radius-medium)",
+  "message-bar-border-width": "var(--border-width)",
+  "message-bar-container-min-height": "var(--size-item-large)",
+  "message-bar-icon-color": "var(--icon-color-information)",
+  "message-bar-icon-size": "var(--icon-size)",
+  "message-bar-text-color": "var(--text-color)",
   "toggle-background-color": "var(--button-background-color)",
   "toggle-background-color-hover": "var(--button-background-color-hover)",
   "toggle-background-color-active": "var(--button-background-color-active)",

--- a/src/vendor/firefox/tools/lint/stylelint/stylelint-plugin-mozilla/config.mjs
+++ b/src/vendor/firefox/tools/lint/stylelint/stylelint-plugin-mozilla/config.mjs
@@ -73,6 +73,15 @@ const systemColorSuggestions = {
   windowtext: "var(--text-color)",
 };
 
+// Some "primitive" color tokens can be used directly for background-color, color, fill, stroke, etc.
+const versatileColorTokens = [
+  "--color-accent-primary",
+  "--color-accent-primary-hover",
+  "--color-accent-primary-active",
+  "--color-accent-primary-selected",
+  "--color-accent-attention",
+];
+
 /** @type {PropertyTypeConfig} */
 const BackgroundColor = {
   allow: [
@@ -155,6 +164,7 @@ const BackgroundColor = {
     "--urlbarview-background-color-selected",
     "--urlbarView-result-button-hover-background-color",
     "--urlbarView-result-button-selected-background-color",
+    ...versatileColorTokens,
   ],
   tokenTypes: ["background-color"],
   aliasTokenTypes: ["color", "text-color", "border-color", "icon-color"],
@@ -224,6 +234,7 @@ const Fill = {
     "currentColor",
     "transparent",
   ],
+  allowedTokens: [...versatileColorTokens],
   allowFunctions: ["url"],
   tokenTypes: ["icon-color"],
   aliasTokenTypes: [
@@ -248,6 +259,7 @@ const FontSize = {
     "xxx-large",
     "smaller",
     "larger",
+    "1em",
   ],
   tokenTypes: ["font-size"],
 };
@@ -283,7 +295,8 @@ const BorderColor = {
     "0",
   ],
   allowAlias: [...SYSTEM_COLORS],
-  tokenTypes: ["border-color", "border", "outline"],
+  allowedTokens: [...versatileColorTokens],
+  tokenTypes: ["border-color", "border", "outline-color", "outline"],
   aliasTokenTypes: ["color", "background-color", "text-color"],
   customFixes: customColorFixes,
   customSuggestions: systemColorSuggestions,
@@ -309,7 +322,7 @@ const BorderStyle = {
 /** @type {PropertyTypeConfig} */
 const BorderWidth = {
   allow: ["0"],
-  tokenTypes: ["border-width", "outline"],
+  tokenTypes: ["border-width", "outline-width", "outline"],
   allowUnits: true,
 };
 
@@ -356,6 +369,7 @@ const FlexShorthand = {
 const TextColor = {
   allow: ["currentColor", "white", "black"],
   allowAlias: [...SYSTEM_COLORS],
+  allowedTokens: [...versatileColorTokens],
   tokenTypes: ["text-color", "icon-color"],
   aliasTokenTypes: ["color", "background-color", "border-color"],
   customFixes: customColorFixes,
@@ -416,6 +430,7 @@ const Size = {
 const Stroke = {
   allow: ["none", "context-stroke", "currentColor", "transparent"],
   allowFunctions: ["url"],
+  allowedTokens: [...versatileColorTokens],
   tokenTypes: ["icon-color"],
   aliasTokenTypes: [
     "background-color",

--- a/src/vendor/firefox/tools/lint/stylelint/stylelint-plugin-mozilla/tests/use-design-tokens.border-color.tests.mjs
+++ b/src/vendor/firefox/tools/lint/stylelint/stylelint-plugin-mozilla/tests/use-design-tokens.border-color.tests.mjs
@@ -220,7 +220,12 @@ testRule({
   reject: [
     {
       code: ".a { border-color: #666; }",
-      message: messages.rejected("#666", ["border-color", "border", "outline"]),
+      message: messages.rejected("#666", [
+        "border-color",
+        "border",
+        "outline-color",
+        "outline",
+      ]),
       description: "#666 should use a border-color design token.",
     },
     {
@@ -228,8 +233,10 @@ testRule({
       message: messages.rejected("2px solid #666", [
         "border-color",
         "border",
+        "outline-color",
         "outline",
         "border-width",
+        "outline-width",
       ]),
       description: "2px solid #666 should use a border-color design token.",
     },
@@ -238,6 +245,7 @@ testRule({
       message: messages.rejected("oklch(69% 0.19 15)", [
         "border-color",
         "border",
+        "outline-color",
         "outline",
       ]),
       description: "oklch(69% 0.19 15) should use a border-color design token.",
@@ -247,8 +255,10 @@ testRule({
       message: messages.rejected("3px dashed oklch(42 42 42)", [
         "border-color",
         "border",
+        "outline-color",
         "outline",
         "border-width",
+        "outline-width",
       ]),
       description:
         "3px dashed oklch(42 42 42) should use a border-color design token.",
@@ -258,6 +268,7 @@ testRule({
       message: messages.rejected("rgba(42 42 42 / 0.15)", [
         "border-color",
         "border",
+        "outline-color",
         "outline",
       ]),
       description:
@@ -274,8 +285,10 @@ testRule({
       message: messages.rejected("3px dashed rgba(42 42 42 / 0.15)", [
         "border-color",
         "border",
+        "outline-color",
         "outline",
         "border-width",
+        "outline-width",
       ]),
       description:
         "3px dashed rgba(42 42 42 / 0.15) should use a border-color design token.",
@@ -285,8 +298,10 @@ testRule({
       message: messages.rejected("1px solid #666666", [
         "border-color",
         "border",
+        "outline-color",
         "outline",
         "border-width",
+        "outline-width",
       ]),
       description: "1px solid #666666 should use a border-color design token.",
     },
@@ -295,6 +310,7 @@ testRule({
       message: messages.rejected("rgb(10 20 30)", [
         "border-color",
         "border",
+        "outline-color",
         "outline",
       ]),
       description: "rgb(10 20 30) should use a border-color design token.",
@@ -304,8 +320,10 @@ testRule({
       message: messages.rejected("4px dotted #666", [
         "border-color",
         "border",
+        "outline-color",
         "outline",
         "border-width",
+        "outline-width",
       ]),
       description: "4px dotted #666 should use a border-color design token.",
     },
@@ -314,6 +332,7 @@ testRule({
       message: messages.rejected("oklch(69% 0.19 15)", [
         "border-color",
         "border",
+        "outline-color",
         "outline",
       ]),
       description: "oklch(69% 0.19 15) should use a border-color design token.",
@@ -323,8 +342,10 @@ testRule({
       message: messages.rejected("medium solid color-mix(in srgb, red, blue)", [
         "border-color",
         "border",
+        "outline-color",
         "outline",
         "border-width",
+        "outline-width",
       ]),
       description:
         "color-mix(in srgb, red, blue) should use a border-color design token.",
@@ -334,6 +355,7 @@ testRule({
       message: messages.rejected("oklch(69% 0.19 15)", [
         "border-color",
         "border",
+        "outline-color",
         "outline",
       ]),
       description: "oklch(69% 0.19 15) should use a border-color design token.",
@@ -343,8 +365,10 @@ testRule({
       message: messages.rejected("thin double #191919", [
         "border-color",
         "border",
+        "outline-color",
         "outline",
         "border-width",
+        "outline-width",
       ]),
       description:
         "thin double #989898 should use a border-color design token.",
@@ -354,6 +378,7 @@ testRule({
       message: messages.rejected("oklch(69% 0.19 15)", [
         "border-color",
         "border",
+        "outline-color",
         "outline",
       ]),
       description: "oklch(69% 0.19 15) should use a border-color design token.",
@@ -363,8 +388,10 @@ testRule({
       message: messages.rejected("2px solid #666", [
         "border-color",
         "border",
+        "outline-color",
         "outline",
         "border-width",
+        "outline-width",
       ]),
       description: "2px solid #616263 should use a border-color design token.",
     },
@@ -373,6 +400,7 @@ testRule({
       message: messages.rejected("rgba(0 0 0 / 0.25)", [
         "border-color",
         "border",
+        "outline-color",
         "outline",
       ]),
       description: "rgba(0 0 0 / 0.25) should use a border-color design token.",
@@ -382,8 +410,10 @@ testRule({
       message: messages.rejected("1px solid var(--random-token, #666)", [
         "border-color",
         "border",
+        "outline-color",
         "outline",
         "border-width",
+        "outline-width",
       ]),
       description:
         "1px solid var(--random-token, #666) should use a border-color design token.",
@@ -392,7 +422,14 @@ testRule({
       code: ".a { border: 1px solid var(--random-token, var(--color-gray-50)); }",
       message: messages.rejected(
         "1px solid var(--random-token, var(--color-gray-50))",
-        ["border-color", "border", "outline", "border-width"]
+        [
+          "border-color",
+          "border",
+          "outline-color",
+          "outline",
+          "border-width",
+          "outline-width",
+        ]
       ),
       description:
         "1px solid var(--random-token, var(--color-gray-50)) should use a border-color design token.",
@@ -405,6 +442,7 @@ testRule({
       message: messages.rejected("var(--custom-token)", [
         "border-color",
         "border",
+        "outline-color",
         "outline",
       ]),
       description:
@@ -418,6 +456,7 @@ testRule({
       message: messages.rejected("var(--random-token, var(--custom-token))", [
         "border-color",
         "border",
+        "outline-color",
         "outline",
       ]),
       description:
@@ -428,8 +467,10 @@ testRule({
       message: messages.rejected("1px solid var(--color-gray-20)", [
         "border-color",
         "border",
+        "outline-color",
         "outline",
         "border-width",
+        "outline-width",
       ]),
       description:
         "1px solid var(--color-gray-20) should use a border-color design token.",
@@ -442,8 +483,10 @@ testRule({
       message: messages.rejected("1px solid var(--custom-token)", [
         "border-color",
         "border",
+        "outline-color",
         "outline",
         "border-width",
+        "outline-width",
       ]),
       description:
         "1px solid var(--custom-token) should use a border-color design token.",
@@ -452,7 +495,7 @@ testRule({
       code: ".a { border-color: FieldText; }",
       message: messages.warning(
         "FieldText",
-        "a border-color, border or outline design token"
+        "a border-color, border, outline-color or outline design token"
       ),
       description: "FieldText should use a border-color design token.",
     },
@@ -466,7 +509,14 @@ testRule({
       code: ".a { border: 1px solid color-mix(in oklch, var(--color-gray-20) 20%, transparent); }",
       message: messages.rejected(
         "1px solid color-mix(in oklch, var(--color-gray-20) 20%, transparent)",
-        ["border-color", "border", "outline", "border-width"]
+        [
+          "border-color",
+          "border",
+          "outline-color",
+          "outline",
+          "border-width",
+          "outline-width",
+        ]
       ),
       description:
         "1px solid color-mix(in oklch, var(--color-gray-20) 20%, transparent) should use a border-color design token.",
@@ -475,7 +525,7 @@ testRule({
       code: ".a { border-color: light-dark(var(--color-gray-20), var(--color-gray-80)); }",
       message: messages.rejected(
         "light-dark(var(--color-gray-20), var(--color-gray-80))",
-        ["border-color", "border", "outline"]
+        ["border-color", "border", "outline-color", "outline"]
       ),
       description:
         "light-dark(var(--color-gray-20), var(--color-gray-80)) should use a border-color design token.",
@@ -484,7 +534,14 @@ testRule({
       code: ".a { border: 1px solid oklch(from var(--color-gray-20) l c h / 20%); }",
       message: messages.rejected(
         "1px solid oklch(from var(--color-gray-20) l c h / 20%)",
-        ["border-color", "border", "outline", "border-width"]
+        [
+          "border-color",
+          "border",
+          "outline-color",
+          "outline",
+          "border-width",
+          "outline-width",
+        ]
       ),
       description:
         "1px solid oklch(from var(--color-gray-20) l c h / 20%) should use a border-color design token.",
@@ -503,7 +560,7 @@ testRule({
       fixed: ".a { border-color: white; }",
       message: messages.rejected(
         "#fff",
-        ["border-color", "border", "outline"],
+        ["border-color", "border", "outline-color", "outline"],
         "white"
       ),
       description: "#fff should be fixed to white",
@@ -513,7 +570,14 @@ testRule({
       fixed: ".a { border: 1px solid white; }",
       message: messages.rejected(
         "1px solid #ffffff",
-        ["border-color", "border", "outline", "border-width"],
+        [
+          "border-color",
+          "border",
+          "outline-color",
+          "outline",
+          "border-width",
+          "outline-width",
+        ],
         "1px solid white"
       ),
       description: "#ffffff should be fixed to white",
@@ -523,7 +587,7 @@ testRule({
       fixed: ".a { outline-color: white; }",
       message: messages.rejected(
         "#FFF",
-        ["border-color", "border", "outline"],
+        ["border-color", "border", "outline-color", "outline"],
         "white"
       ),
       description: "#FFF should be fixed to white",
@@ -533,7 +597,7 @@ testRule({
       fixed: ".a { border-left-color: white; }",
       message: messages.rejected(
         "#FFFFFF",
-        ["border-color", "border", "outline"],
+        ["border-color", "border", "outline-color", "outline"],
         "white"
       ),
       description: "#FFFFFF should be fixed to white",
@@ -543,7 +607,14 @@ testRule({
       fixed: ".a { outline: 1px solid black; }",
       message: messages.rejected(
         "1px solid #000",
-        ["border-color", "border", "outline", "border-width"],
+        [
+          "border-color",
+          "border",
+          "outline-color",
+          "outline",
+          "border-width",
+          "outline-width",
+        ],
         "1px solid black"
       ),
       description: "#000 should be fixed to black",
@@ -553,7 +624,7 @@ testRule({
       fixed: ".a { border-block-end-color: black; }",
       message: messages.rejected(
         "#000000",
-        ["border-color", "border", "outline"],
+        ["border-color", "border", "outline-color", "outline"],
         "black"
       ),
       description: "#000000 should be fixed to black",

--- a/src/vendor/firefox/vendor-metadata.json
+++ b/src/vendor/firefox/vendor-metadata.json
@@ -1,13 +1,13 @@
 {
   "sourceRepo": "mozilla-firefox/firefox",
   "originUrl": "git@github.com:mozilla-firefox/firefox.git",
-  "revision": "5ff69e076a8d8cc38707e29d5a8d7c42d5798a8b",
-  "revisionDate": "2026-04-07T13:14:20Z",
+  "revision": "76e27fdaa88b45ffb740b6bbd21bc016cee3db25",
+  "revisionDate": "2026-04-14T06:35:18Z",
   "branch": "main",
   "paths": [
     "tools/lint/stylelint/stylelint-plugin-mozilla",
     "toolkit/themes/shared/design-system/dist/tokens-table.mjs",
     "toolkit/themes/shared/design-system/dist/semantic-categories.mjs"
   ],
-  "syncedAt": "2026-04-07T13:17:42.809Z"
+  "syncedAt": "2026-04-14T09:20:27.384Z"
 }


### PR DESCRIPTION
* Updates vendored code following the landing of: https://bugzilla.mozilla.org/show_bug.cgi?id=2022975 
* Fix tests due to changes in stylelint plugin throught the addition of `versatileColorTokens` which now allows `--color-accent-primary` which was used in the tests. 
* Fix a bug found where stylelint ignored lines with invalid usage were not correctly ignored. This caused toolkit/themes/shared/in-content/common-shared.css to show up as 98.8% instead of 100% with the new vendored code.
* Add more tests to cover theses cases.