### PR TITLE
Move vi.mock calls alongside imports to fix test-run warnings

### DIFF
--- a/src/lib/externalVars.test.js
+++ b/src/lib/externalVars.test.js
@@ -1,6 +1,8 @@
 import fs from 'fs/promises';
 
 import { getVarData } from './externalVars.js';
+
+vi.mock('node:fs/promises');
 import { getExternalVars } from './externalVars.js';
 import config from '../../config.js';
 
@@ -56,7 +58,6 @@ describe('getExternalVars', () => {
   });
 
   beforeEach(() => {
-    vi.mock('node:fs/promises');
     fs.readFile = vi.fn();
   });
 

--- a/src/lib/fileUtils.test.js
+++ b/src/lib/fileUtils.test.js
@@ -2,6 +2,8 @@ import fs from 'node:fs/promises';
 import path from 'path';
 import { getCssFilesList, convertPathToURI } from './fileUtils.js';
 
+vi.mock('node:fs/promises');
+
 describe('convertPathToURI', () => {
   test('converts windows-style paths to URI-safe format', () => {
     const result = convertPathToURI('src\\styles\\main.css');
@@ -22,7 +24,6 @@ describe('getCssFilesList', () => {
   });
 
   beforeEach(() => {
-    vi.mock('node:fs/promises');
     fs.writeFile = vi.fn();
     fs.readFile = vi.fn();
   });

--- a/src/lib/loadAndAnnotateFile.test.js
+++ b/src/lib/loadAndAnnotateFile.test.js
@@ -1,4 +1,7 @@
 import fs from 'fs/promises';
+
+vi.mock('node:fs/promises');
+
 import loadAndAnnotateFile from './loadAndAnnotateFile.js';
 import { getStatus } from './loadAndAnnotateFile.js';
 
@@ -100,7 +103,6 @@ describe('getStatus', () => {
 
 describe('loadAndAnnotateFile', () => {
   beforeEach(() => {
-    vi.mock('node:fs/promises');
     fs.readFile = vi.fn();
   });
 

--- a/src/lib/propagationUtils.test.js
+++ b/src/lib/propagationUtils.test.js
@@ -7,6 +7,8 @@ import {
 } from './propagationUtils.js';
 import config from '../../config.js';
 
+vi.mock('node:fs/promises');
+
 const originalConfig = { ...config };
 
 describe('getPropagationData', () => {
@@ -21,7 +23,6 @@ describe('getPropagationData', () => {
   });
 
   beforeEach(() => {
-    vi.mock('node:fs/promises');
     fs.writeFile = vi.fn();
     fs.readFile = vi.fn();
   });


### PR DESCRIPTION
Moving the `vi.mock()` reflects what happens in the transform see https://vitest.dev/guide/mocking/modules#how-it-works

This was showing up as a warning in test runs like so: 

```
Warning: A vi.mock('node:fs/promises') call in "./src/lib/propagationUtils.test.js" is not at the top level of the module. Although it appears nested, it will be hoisted and executed before any tests run. Move it to the top level to reflect its actual execution order. This will become an error in a future version.
See: https://vitest.dev/guide/mocking/modules#how-it-works
``` 